### PR TITLE
Instant.fromString(): fix + test

### DIFF
--- a/lib/instant.mjs
+++ b/lib/instant.mjs
@@ -45,7 +45,10 @@ export class Instant {
     if (!match) {
       throw new Error(`invalid date-time-string ${string}`);
     }
-    const milliseconds = Date.UTC(number(match[1]), number(match[2]) - 1, number(match[3]), number(match[4]), number(match[5]), number(match[6]), number(match[7]));
+
+    const dateString = `${match[1]}-${match[2]}-${match[3]}T${match[4]}:${match[5]}:${match[6]}.${match[7]}Z`;
+    const date = new Date(Date.parse(dateString));
+    const milliseconds = date.getTime();
     const nanoseconds = number(match[8]);
 
     const instant = Object.create(Instant.prototype);

--- a/test/instant.mjs
+++ b/test/instant.mjs
@@ -1,4 +1,4 @@
-#! /usr/bin/env node --experimental-modules
+#!/usr/bin/env -S node --experimental-modules
 
 /*
 ** Copyright (C) 2018 Bloomberg LP. All rights reserved.
@@ -8,6 +8,9 @@
 import test from 'tape';
 
 import { Instant } from '../lib/instant.mjs';
+
+const HIGHEST_YYYY_DATE = new Date(Date.parse('9999-12-31T23:59:59.999Z'));
+const LOWEST_YYYY_DATE  = new Date(Date.parse('0000-01-01T00:00:00.000Z'));
 
 test('new Instant()', ({ equal, throws, end })=>{
   equal(typeof Instant, 'function');
@@ -53,4 +56,66 @@ test('Instant.fromNanoseconds()', ({ equal, throws, end }) => {
   equal(instant.toString(), '1976-11-18T15:23:30.123456789Z');
   throws(() => Instant.fromEpochNanoseconds(0));
   end();
+});
+
+function dateToInstant(date) {
+  const isoString = date.toISOString();
+  const instantString = `${isoString.slice(0, -1)}000000Z`;
+  return Instant.fromString(instantString);
+}
+
+function instantToDate(instant) {
+  return new Date(instant.milliseconds);
+}
+
+test('Instant.fromString()', ({ test, end }) => {
+  let testCount = 0;
+
+  const dates = [
+    new Date(Date.UTC(0)),
+    new Date(Date.UTC(77)),
+    new Date(Date.UTC(1, 2, 3, 4, 5, 6, 7)),
+    new Date(Date.UTC(1993, 11, 23, 5, 8, 13, 21)),
+    new Date(-9999999999999),
+    new Date(99999999999999),
+    HIGHEST_YYYY_DATE,
+    LOWEST_YYYY_DATE,
+  ];
+
+  dates.forEach((expectedDate) => {
+    test(`Instant.fromString() 1.${++testCount}`, ({ equal, end }) => {
+      const instant = dateToInstant(expectedDate);
+      const actualDate = instantToDate(instant);
+
+      equal(actualDate.toISOString(), expectedDate.toISOString());
+      equal(instant.seconds, Math.floor(actualDate / 1000));
+      equal(instant.milliseconds, actualDate.getTime());
+      equal(instant.microseconds, BigInt(actualDate.getTime()) * 1000n);
+      equal(instant.nanoseconds,  BigInt(actualDate.getTime()) * 1000000n);
+
+      end();
+    });
+  });
+
+  const strings = [
+    '0000-01-01T00:00:00.000000000Z',
+    '0045-12-31T23:59:59.999999999Z',
+    '9999-12-31T23:59:59.999999999Z',
+    '1970-01-01T00:00:00.000000000Z',
+    '1976-11-18T15:23:30.000000000Z',
+    '1976-11-18T15:23:30.123456789Z',
+  ];
+
+  strings.forEach((expectedString) => {
+    test(`Instant.fromString() 2.${++testCount}`, ({ equal, end }) => {
+      const instant = Instant.fromString(expectedString);
+      const actualString = instant.toString();
+
+      equal(actualString, expectedString);
+      end();
+    });
+  });
+
+  end();
+
 });


### PR DESCRIPTION
- Fix a bug wherein a string with year 0-99 would be converted to year
1900-1999. Date.UTC does this conversion, but Date.parse does not
- Add comprehensive tests
- fix the shebang line to work on my machine. if it breaks others, I can
switch it back