### PR TITLE
CivilDateTime.plus(): fix handling of negative overflow of day

### DIFF
--- a/lib/civil/shared.mjs
+++ b/lib/civil/shared.mjs
@@ -37,7 +37,7 @@ export function plus(
 
   while (day < 1) {
     month -= 1;
-    day = daysInMonth(year, month) - day;
+    day = daysInMonth(year, month) + day;
     if (month < 1) { month = 12; year -= 1; }
   }
   while (day > daysInMonth(year, month)) {

--- a/test/datetime.mjs
+++ b/test/datetime.mjs
@@ -60,6 +60,34 @@ test('datetime properties', ({ equal, end }) => {
   instance = instance.with({ year: 2016, month: 1, day: 2 });
   equal(instance.weekOfYear, 53);
 
+  instance = instance.plus({ years: -5, months: -2, days: -10 });
+  equal(instance.year, 2010);
+  equal(instance.month, 10);
+  equal(instance.day, 23);
+  equal(instance.hour, 15);
+  equal(instance.minute, 23);
+  equal(instance.second, 30);
+  equal(instance.millisecond, 123);
+  equal(instance.microsecond, 456);
+  equal(instance.nanosecond, 789);
+  equal(instance.dayOfWeek, 6);
+  equal(instance.dayOfYear, 296);
+  equal(instance.weekOfYear, 42);
+
+  instance = instance.plus({ hours: -23, minutes: -50, seconds: -99, milliseconds: -500, microseconds: -2300, nanoseconds: -1000 });
+  equal(instance.year, 2010);
+  equal(instance.month, 10);
+  equal(instance.day, 22);
+  equal(instance.hour, 15);
+  equal(instance.minute, 31);
+  equal(instance.second, 50);
+  equal(instance.millisecond, 621);
+  equal(instance.microsecond, 155);
+  equal(instance.nanosecond, 789);
+  equal(instance.dayOfWeek, 5);
+  equal(instance.dayOfYear, 295);
+  equal(instance.weekOfYear, 42);
+
   end();
 });
 


### PR DESCRIPTION
Hello, I found a possible bug that a negative overflow of day results in a wrong result returned by `CivilDateTime#plus` (and others which rely on `plus` in `lib/civil/shared.mjs`).

This PR fixes the bug and adds tests for that.

Thank you.

**Reproduction of the bug**

```js
const reiwa = new CivilDateTime(2019, 5, 1, 0, 0);
const twoDaysBefore = reiwa.plus({ days: -2 });
console.log(twoDaysBefore.month); // Expected: 4  / Actual: 5
console.log(twoDaysBefore.day);   // Expected: 29 / Actual: 1
```