### PR TITLE
Fix index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,10 +1,10 @@
 export class Instant {
-  constructor(nanos_since_epoch : BigInt);
+  constructor(nanos_since_epoch : bigint);
 
   readonly seconds: number;
   readonly milliseconds: number;
-  readonly microseconds: BigInt;
-  readonly nanoseconds: BigInt;
+  readonly microseconds: bigint;
+  readonly nanoseconds: bigint;
 
   withZone(timeZone : string) : ZonedDateTime;
   toString() : string;
@@ -13,8 +13,8 @@ export class Instant {
   static fromString(isostring: string) : Instant;
   static fromEpochSeconds(seconds: number) : Instant;
   static fromEpochMilliseconds(milliseconds : number) : Instant;
-  static fromEpochMicroseconds(micros: BigInt) : Instant;
-  static fromEpochNanoseconds(nanos: BigInt) : Instant;
+  static fromEpochMicroseconds(micros: bigint) : Instant;
+  static fromEpochNanoseconds(nanos: bigint) : Instant;
 }
 export class ZonedDateTime {
   constructor(instant : Instant, timeZone: string);
@@ -31,8 +31,8 @@ export class ZonedDateTime {
   static fromString(isostring: string) : ZonedDateTime;
   static fromEpochSeconds(seconds : number, zone : string) : ZonedDateTime;
   static fromEpochMilliseconds(milliseconds : number, zone : string) : ZonedDateTime;
-  static fromEpochMicroseconds(micros : BigInt, zone : string) : ZonedDateTime;
-  static fromEpochNanoseconds(nanos : BigInt, zone : string) : ZonedDateTime;
+  static fromEpochMicroseconds(micros : bigint, zone : string) : ZonedDateTime;
+  static fromEpochNanoseconds(nanos : bigint, zone : string) : ZonedDateTime;
 }
 
 export interface CivilDateValues {
@@ -52,7 +52,7 @@ export interface CivilDateTimeValues extends CivilTimeValues, CivilDateValues {
 }
 
 export class CivilDateTime {
-  constructor(years : number, months : number, days : number, hours : number, minutes : number, seconds : number = 0, nanoseconds : number = 0);
+  constructor(years : number, months : number, days : number, hours : number, minutes : number, seconds? : number /* = 0 */, nanoseconds? : number /* = 0 */);
 
   readonly year : number;
   readonly month : number;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "tc39-proposal-temporal",
-  "version": "2.0.0",
+  "name": "@std-proposal/temporal",
+  "version": "0.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -385,6 +385,12 @@
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
+    "typescript": {
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.5.tgz",
+      "integrity": "sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==",
       "dev": true
     },
     "wrappy": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "test:es7": "for t in $(ls test/*.mjs); do \"./$t\"; done",
     "test:262": "npm run build && for FILE in $(find test262/temporal -type f -name '*.js' | grep -v 'test262/node.js'); do node -r ./test262/node.js $FILE; if [ $? = 0 ]; then echo 'OK ' $FILE; else echo 'FAIL ' $FILE; fi; done",
-    "test": "npm run test:es7 && npm run test:262",
+    "test:dts": "tsc --noEmit --strict index.d.ts",
+    "test": "npm run test:es7 && npm run test:262 && npm run test:dts",
     "prepublishOnly": "npm run build",
     "build": "rollup -c rollup.config.js"
   },
@@ -26,6 +27,7 @@
     "rollup": "^1.7.0",
     "rollup-plugin-license": "^0.8.1",
     "rollup-plugin-node-resolve": "^4.0.1",
-    "tape": "^4.10.1"
+    "tape": "^4.10.1",
+    "typescript": "^3.4.5"
   }
 }


### PR DESCRIPTION
* Fixed the type of bigint. `BigInt` is a box object for `bigint`.
* Removed the default parameter values from index.d.ts which are just illegal.
* Added a simple type checking in `npm test`

BTW I believe it's better if the codebase is migrated to TypeScript with only ECMA-262 features (i.e. no `enum`, no `namespace`, etc.).